### PR TITLE
Workaround for error 'USBErrorNotSupported' 

### DIFF
--- a/sn8/flashsn8.py
+++ b/sn8/flashsn8.py
@@ -387,6 +387,8 @@ def main():
                     device_handle.detachKernelDriver(interface)
                 except usb1.USBErrorNotFound:
                     pass
+                except usb1.USBErrorNotSupported:
+                    pass
                 device_handle.claimInterface(interface)
         else:
             device_handle.setConfiguration(1)


### PR DESCRIPTION
# Issue

When the `flashsn8` is used in MS Windows, it always return a following error:

```
raise __STATUS_TO_EXCEPTION_DICT.get(value, __USBError)(value)
usb1.USBErrorNotSupported: LIBUSB_ERROR_NOT_SUPPORTED [-12]
```
example: https://github.com/haborite/ku1255-firmware-modifier/issues/2

# Cause

`detachKernelDriver()`  always fails in MS Windows without exception.
Use of WinUSB or libusb-win32 make no effects.

# Solution

Catch the error `usb1.USBErrorNotSupported` and pass it, same as `usb1.USBErrorNotFound`.